### PR TITLE
Apply shadcn/ui styling to travel views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.DS_Store
+dist
+npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Travel Studio
+
+Aplicación React (Vite + TypeScript) que muestra una colección de viajes planeados. La pantalla principal enseña tarjetas con los destinos guardados y permite abrir el itinerario detallado del viaje a Nueva Orleans.
+
+La interfaz está maquetada con [Tailwind CSS](https://tailwindcss.com/) y componentes de [shadcn/ui](https://ui.shadcn.com/), lo que facilita mantener un estilo moderno y consistente.
+
+## 🚀 Scripts
+
+> Requiere Node.js 18 o superior.
+
+```bash
+npm install
+npm run dev
+```
+
+La app se expone en `http://localhost:5173`.
+
+## 🧭 Características
+
+- Tarjetas de viajes con fechas, ciudad y highlights principales.
+- Navegación con React Router hacia la vista de detalle.
+- Vista "Basic Information" para Nueva Orleans con hotel, zona horaria y destacados.
+- Sección de itinerario que agrupa las actividades por día.
+- Botón flotante de “+” listo para futuras expansiones.
+
+Los datos se encuentran en [`src/data/travels.ts`](src/data/travels.ts) y pueden ampliarse con nuevos destinos y actividades.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Travel Planner</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400..800&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "travels",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
+    "@radix-ui/react-slot": "^1.0.2",
+    "lucide-react": "^0.368.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3",
+    "tailwind-merge": "^2.2.1"
+  },
+  "devDependencies": {
+    "@tailwindcss/forms": "^0.5.7",
+    "@types/react": "^18.2.61",
+    "@types/react-dom": "^18.2.19",
+    "@typescript-eslint/eslint-plugin": "^7.4.0",
+    "@typescript-eslint/parser": "^7.4.0",
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.17",
+    "eslint": "^8.57.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.5",
+    "postcss": "^8.4.35",
+    "tailwindcss": "^3.4.3",
+    "typescript": "^5.4.0",
+    "vite": "^5.2.0"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,14 @@
+import { Route, Routes } from 'react-router-dom';
+import HomePage from './pages/HomePage';
+import TravelDetailPage from './pages/TravelDetailPage';
+
+function App() {
+  return (
+    <Routes>
+      <Route path="/" element={<HomePage />} />
+      <Route path="/travels/:travelId" element={<TravelDetailPage />} />
+    </Routes>
+  );
+}
+
+export default App;

--- a/src/components/TravelCard.tsx
+++ b/src/components/TravelCard.tsx
@@ -1,0 +1,63 @@
+import { MapPin, CalendarDays, Globe2, type LucideIcon } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+import type { Travel } from '../data/travels';
+import { Badge } from './ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card';
+
+type TravelCardProps = {
+  travel: Travel;
+};
+
+const metaItems: Array<{
+  icon: LucideIcon;
+  label: string;
+  getValue: (travel: Travel) => string;
+}> = [
+  { icon: CalendarDays, label: 'Fechas', getValue: (travel: Travel) => travel.dateRange },
+  { icon: MapPin, label: 'Ciudad', getValue: (travel: Travel) => travel.city },
+  { icon: Globe2, label: 'País', getValue: (travel: Travel) => travel.country },
+];
+
+const TravelCard = ({ travel }: TravelCardProps) => {
+  const { id, title, description, highlights } = travel;
+
+  return (
+    <Link
+      to={`/travels/${id}`}
+      className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      aria-label={`Abrir itinerario ${title}`}
+    >
+      <Card className="h-full transition hover:-translate-y-0.5 hover:shadow-lg">
+        <CardHeader>
+          <CardTitle className="text-2xl">{title}</CardTitle>
+          <CardDescription>{description}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <ul className="grid gap-3 text-sm text-muted-foreground md:grid-cols-3">
+            {metaItems.map(({ icon: Icon, label, getValue }) => (
+              <li key={label} className="flex items-center gap-2 rounded-lg border border-dashed border-border bg-muted/50 px-3 py-2">
+                <Icon className="h-4 w-4 text-primary" aria-hidden />
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-muted-foreground/80">{label}</p>
+                  <p className="font-medium text-foreground">{getValue(travel)}</p>
+                </div>
+              </li>
+            ))}
+          </ul>
+          {highlights.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {highlights.map((highlight) => (
+                <Badge key={highlight} variant="outline" className="border-border bg-background text-sm">
+                  {highlight}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </Link>
+  );
+};
+
+export default TravelCard;

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '../../lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-secondary text-secondary-foreground',
+        accent: 'border-transparent bg-accent text-accent-foreground',
+        outline: 'text-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '../../lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground shadow hover:bg-primary/90',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+    );
+  }
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+
+import { cn } from '../../lib/utils';
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('rounded-xl border bg-card text-card-foreground shadow-sm', className)} {...props} />
+  )
+);
+Card.displayName = 'Card';
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+  )
+);
+CardHeader.displayName = 'CardHeader';
+
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3 ref={ref} className={cn('text-2xl font-semibold leading-none tracking-tight', className)} {...props} />
+  )
+);
+CardTitle.displayName = 'CardTitle';
+
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+  )
+);
+CardDescription.displayName = 'CardDescription';
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+  )
+);
+CardContent.displayName = 'CardContent';
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />
+  )
+);
+CardFooter.displayName = 'CardFooter';
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/src/data/travels.ts
+++ b/src/data/travels.ts
@@ -1,0 +1,112 @@
+export type Activity = {
+  time: string;
+  title: string;
+  category: string;
+};
+
+export type DayPlan = {
+  date: string;
+  label: string;
+  activities: Activity[];
+};
+
+export type Travel = {
+  id: string;
+  title: string;
+  city: string;
+  country: string;
+  dateRange: string;
+  description: string;
+  timezone: string;
+  hotel: {
+    name: string;
+    address: string;
+    checkIn: string;
+    checkOut: string;
+  };
+  highlights: string[];
+  days: DayPlan[];
+};
+
+export const travels: Travel[] = [
+  {
+    id: 'new-orleans',
+    title: 'Nueva Orleans – 7–11 nov 2025',
+    city: 'New Orleans, Louisiana',
+    country: 'United States',
+    dateRange: '7 – 11 noviembre 2025',
+    description:
+      'Un fin de semana largo enfocado en la escena culinaria, cultura vibrante y experiencias únicas en la cuna del jazz.',
+    timezone: 'America/Chicago',
+    hotel: {
+      name: 'Hotel de la Poste – French Quarter',
+      address: '316 Chartres St, New Orleans, LA 70130',
+      checkIn: '2025-11-07T15:00:00',
+      checkOut: '2025-11-11T11:00:00'
+    },
+    highlights: [
+      'Brunch imperdible en Willa Jean',
+      'Cocteles artesanales en French 75 Bar',
+      'Museo de Farmacia y magia en Haus of Hoodoo'
+    ],
+    days: [
+      {
+        date: '2025-11-07',
+        label: 'Viernes – Llegada',
+        activities: [
+          { time: '17:16', title: 'Llegada a MSY', category: 'Transporte' },
+          {
+            time: '20:00',
+            title: 'Cena en Arnaud’s + French 75 Bar',
+            category: 'Comida'
+          }
+        ]
+      },
+      {
+        date: '2025-11-08',
+        label: 'Sábado – Brunch, Cultura y Vibes',
+        activities: [
+          { time: '09:00', title: 'Brunch en Willa Jean', category: 'Comida' },
+          { time: '11:00', title: 'Pharmacy Museum', category: 'Museo' },
+          { time: '15:00', title: 'Haus of Hoodoo', category: 'Cultura' }
+        ]
+      }
+    ]
+  },
+  {
+    id: 'lisbon',
+    title: 'Lisboa Creativa',
+    city: 'Lisbon, Portugal',
+    country: 'Portugal',
+    dateRange: '18 – 23 marzo 2026',
+    description:
+      'Explora miradores, cafés históricos y un circuito de arte urbano en la capital portuguesa.',
+    timezone: 'Europe/Lisbon',
+    hotel: {
+      name: 'Casa do Bairro Loft',
+      address: 'Travessa do Caldeira 19, 1200-088 Lisboa',
+      checkIn: '2026-03-18T15:00:00',
+      checkOut: '2026-03-23T11:00:00'
+    },
+    highlights: ['Tram 28 al atardecer', 'Pastéis de nata en Belém', 'Tour de arte urbano con guía local'],
+    days: []
+  },
+  {
+    id: 'kyoto',
+    title: 'Kyoto Slow Travel',
+    city: 'Kyoto',
+    country: 'Japan',
+    dateRange: '9 – 15 abril 2026',
+    description:
+      'Templos, jardines zen y experiencias culinarias que celebran la tradición japonesa.',
+    timezone: 'Asia/Tokyo',
+    hotel: {
+      name: 'Ryokan Sakura',
+      address: 'Higashiyama-ku, Kyoto',
+      checkIn: '2026-04-09T15:00:00',
+      checkOut: '2026-04-15T11:00:00'
+    },
+    highlights: ['Ceremonia del té en Gion', 'Sendero de la Filosofía', 'Cena kaiseki con ingredientes locales'],
+    days: []
+  }
+];

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,60 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 224 71% 4%;
+
+    --card: 0 0% 100%;
+    --card-foreground: 224 71% 4%;
+
+    --popover: 0 0% 100%;
+    --popover-foreground: 224 71% 4%;
+
+    --primary: 222 89% 53%;
+    --primary-foreground: 210 40% 98%;
+
+    --secondary: 210 40% 96%;
+    --secondary-foreground: 222 47% 11%;
+
+    --muted: 210 40% 96%;
+    --muted-foreground: 215 16% 47%;
+
+    --accent: 25 95% 53%;
+    --accent-foreground: 210 40% 98%;
+
+    --destructive: 0 84% 60%;
+    --destructive-foreground: 210 40% 98%;
+
+    --border: 214 32% 91%;
+    --input: 214 32% 91%;
+    --ring: 222 89% 53%;
+
+    --radius: 0.75rem;
+  }
+
+  * {
+    @apply border-border;
+  }
+
+  body {
+    @apply min-h-screen bg-background font-sans text-foreground antialiased;
+  }
+}
+
+@layer base {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply font-semibold tracking-tight text-foreground;
+  }
+
+  p {
+    @apply leading-relaxed text-muted-foreground;
+  }
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,33 @@
+import { Plus } from 'lucide-react';
+
+import TravelCard from '../components/TravelCard';
+import { Button } from '../components/ui/button';
+import { travels } from '../data/travels';
+
+const HomePage = () => {
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-6 pb-16 pt-12">
+      <header className="flex flex-col justify-between gap-6 rounded-3xl border bg-gradient-to-br from-primary/10 via-background to-background p-8 shadow-sm sm:flex-row sm:items-center">
+        <div className="space-y-2">
+          <p className="text-sm uppercase tracking-[0.35em] text-primary">Travel Studio</p>
+          <h1 className="text-3xl font-semibold sm:text-4xl">Explora tus experiencias guardadas</h1>
+          <p className="max-w-2xl text-base text-muted-foreground">
+            Elige un destino para ver el itinerario completo. Muy pronto podrás agregar nuevas aventuras desde este mismo panel.
+          </p>
+        </div>
+        <Button type="button" size="icon" variant="secondary" disabled className="h-14 w-14 rounded-full text-primary shadow-inner">
+          <Plus className="h-6 w-6" aria-hidden />
+          <span className="sr-only">Agregar nuevo viaje</span>
+        </Button>
+      </header>
+
+      <section aria-label="Viajes planificados" className="grid gap-6 md:grid-cols-2">
+        {travels.map((travel) => (
+          <TravelCard key={travel.id} travel={travel} />
+        ))}
+      </section>
+    </main>
+  );
+};
+
+export default HomePage;

--- a/src/pages/TravelDetailPage.tsx
+++ b/src/pages/TravelDetailPage.tsx
@@ -1,0 +1,179 @@
+import { CalendarRange, Clock, Hotel, MapPin, Sparkles } from 'lucide-react';
+import { Link, useParams } from 'react-router-dom';
+
+import { Badge } from '../components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
+import { travels } from '../data/travels';
+import { format } from '../utils/format';
+
+const TravelDetailPage = () => {
+  const { travelId } = useParams<{ travelId: string }>();
+  const travel = travels.find((t) => t.id === travelId);
+
+  if (!travel) {
+    return (
+      <main className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-6 pb-16 pt-12">
+        <Link
+          to="/"
+          className="inline-flex w-fit items-center gap-2 text-sm font-medium text-primary transition hover:text-primary/80"
+        >
+          ← Volver
+        </Link>
+        <Card className="border-dashed">
+          <CardHeader>
+            <CardTitle>Itinerario no disponible</CardTitle>
+            <CardDescription>
+              No encontramos ese itinerario. Vuelve a la página principal para seleccionar uno de tus viajes planificados.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </main>
+    );
+  }
+
+  const { title, city, country, timezone, hotel, highlights, days, description, dateRange } = travel;
+
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-12 px-6 pb-20 pt-12">
+      <div className="flex items-center justify-between gap-4">
+        <Link
+          to="/"
+          className="inline-flex items-center gap-2 text-sm font-medium text-primary transition hover:text-primary/80"
+        >
+          ← Volver a viajes
+        </Link>
+        <Badge variant="outline" className="rounded-full border-primary/40 bg-primary/5 text-primary">
+          {dateRange}
+        </Badge>
+      </div>
+
+      <header className="space-y-4">
+        <div className="inline-flex items-center gap-2 rounded-full border border-transparent bg-primary/10 px-4 py-1 text-sm font-medium text-primary">
+          <MapPin className="h-4 w-4" aria-hidden /> {city}, {country}
+        </div>
+        <div className="space-y-3">
+          <h1 className="text-4xl font-semibold sm:text-5xl">{title}</h1>
+          <p className="max-w-2xl text-lg text-muted-foreground">{description}</p>
+        </div>
+      </header>
+
+      <section className="space-y-6">
+        <div className="flex items-center gap-3">
+          <h2 className="text-2xl font-semibold">Basic Information</h2>
+          <Sparkles className="h-5 w-5 text-primary" aria-hidden />
+        </div>
+        <div className="grid gap-6 md:grid-cols-3">
+          <Card className="border-dashed">
+            <CardHeader className="space-y-3">
+              <CardTitle className="flex items-center gap-2 text-lg">
+                <Clock className="h-5 w-5 text-primary" aria-hidden /> Zona horaria
+              </CardTitle>
+              <CardDescription className="text-base text-foreground">{timezone}</CardDescription>
+            </CardHeader>
+          </Card>
+          <Card className="md:col-span-2">
+            <CardHeader className="space-y-3">
+              <CardTitle className="flex items-center gap-2 text-lg">
+                <Hotel className="h-5 w-5 text-primary" aria-hidden /> Hotel
+              </CardTitle>
+              <CardDescription className="text-sm">
+                {hotel.address}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-3 text-sm md:grid-cols-2">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">Nombre</p>
+                <p className="text-base font-medium text-foreground">{hotel.name}</p>
+              </div>
+              <div className="flex flex-col gap-2">
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Check-in</p>
+                  <p className="font-medium text-foreground">{format.datetime(hotel.checkIn)}</p>
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Check-out</p>
+                  <p className="font-medium text-foreground">{format.datetime(hotel.checkOut)}</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+          {highlights.length > 0 && (
+            <Card className="md:col-span-3">
+              <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <CardTitle className="flex items-center gap-2 text-lg">
+                  <CalendarRange className="h-5 w-5 text-primary" aria-hidden /> Highlights
+                </CardTitle>
+                <CardDescription>Momentos que no te puedes perder durante el viaje.</CardDescription>
+              </CardHeader>
+              <CardContent className="flex flex-wrap gap-3">
+                {highlights.map((highlight) => (
+                  <Badge key={highlight} variant="accent" className="text-sm">
+                    {highlight}
+                  </Badge>
+                ))}
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </section>
+
+      <section className="space-y-6">
+        <div className="flex items-center gap-3">
+          <h2 className="text-2xl font-semibold">Itinerario</h2>
+          <CalendarRange className="h-5 w-5 text-primary" aria-hidden />
+        </div>
+        {days.length === 0 ? (
+          <Card className="border-dashed">
+            <CardHeader>
+              <CardTitle>Aún no hay actividades</CardTitle>
+              <CardDescription>
+                Usa el botón “+” en la pantalla principal para comenzar a planificar este viaje cuando la función esté disponible.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        ) : (
+          <div className="space-y-6">
+            {days.map((day) => (
+              <Card key={day.date} className="overflow-hidden">
+                <CardHeader className="border-b bg-muted/40">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div>
+                      <CardTitle className="text-xl">{day.label}</CardTitle>
+                      <CardDescription className="text-sm font-medium text-foreground">
+                        {format.date(day.date)}
+                      </CardDescription>
+                    </div>
+                    <Badge variant="outline" className="bg-background text-xs uppercase tracking-wide">
+                      {day.activities.length} actividades
+                    </Badge>
+                  </div>
+                </CardHeader>
+                <CardContent className="space-y-4 p-6">
+                  <ol className="space-y-3">
+                    {day.activities.map((activity) => (
+                      <li
+                        key={`${day.date}-${activity.time}-${activity.title}`}
+                        className="flex flex-col justify-between gap-3 rounded-lg border bg-card/60 p-4 text-sm shadow-sm sm:flex-row sm:items-center"
+                      >
+                        <div className="space-y-1">
+                          <p className="text-base font-semibold text-foreground">{activity.title}</p>
+                          <p className="text-xs uppercase tracking-wide text-muted-foreground">{activity.category}</p>
+                        </div>
+                        <div className="flex items-center gap-2 text-sm font-medium text-primary">
+                          <Clock className="h-4 w-4" aria-hidden />
+                          {activity.time}
+                        </div>
+                      </li>
+                    ))}
+                  </ol>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+      </section>
+    </main>
+  );
+};
+
+export default TravelDetailPage;

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,28 @@
+const dateFormatter = new Intl.DateTimeFormat('es-ES', {
+  weekday: 'long',
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric'
+});
+
+const timeFormatter = new Intl.DateTimeFormat('es-ES', {
+  hour: '2-digit',
+  minute: '2-digit'
+});
+
+const format = {
+  date: (isoDate: string) => {
+    const date = new Date(isoDate);
+    return dateFormatter.format(date);
+  },
+  time: (isoDate: string) => {
+    const date = new Date(isoDate);
+    return timeFormatter.format(date);
+  },
+  datetime: (isoDate: string) => {
+    const date = new Date(isoDate);
+    return `${dateFormatter.format(date)} · ${timeFormatter.format(date)}`;
+  }
+};
+
+export { format };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,71 @@
+import type { Config } from 'tailwindcss';
+import forms from '@tailwindcss/forms';
+
+const config: Config = {
+  darkMode: ['class'],
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Inter', 'system-ui', 'sans-serif'],
+      },
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+      keyframes: {
+        'accordion-down': {
+          from: { height: '0' },
+          to: { height: 'var(--radix-accordion-content-height)' },
+        },
+        'accordion-up': {
+          from: { height: 'var(--radix-accordion-content-height)' },
+          to: { height: '0' },
+        },
+      },
+      animation: {
+        'accordion-down': 'accordion-down 0.2s ease-out',
+        'accordion-up': 'accordion-up 0.2s ease-out',
+      },
+    },
+  },
+  plugins: [forms],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: '0.0.0.0'
+  }
+});


### PR DESCRIPTION
## Summary
- integrate Tailwind CSS and shadcn/ui configuration to drive the travel planner styles
- restyle the home travel grid and New Orleans detail view with shadcn/ui cards, badges, and icons
- add reusable button, card, and badge primitives for future travel features

## Testing
- npm install *(fails: 403 Forbidden fetching packages in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e6904a87108331b7b0161c4929e853